### PR TITLE
(Feature) Add claimTokens method

### DIFF
--- a/contracts/CrowdsaleTokenExt.sol
+++ b/contracts/CrowdsaleTokenExt.sol
@@ -6,6 +6,8 @@
 
 pragma solidity ^0.4.8;
 
+import "oracles-zeppelin/contracts/token/ERC20.sol";
+
 import './StandardToken.sol';
 import "./UpgradeableToken.sol";
 import "./ReleasableToken.sol";
@@ -122,7 +124,7 @@ contract CrowdsaleTokenExt is ReleasableToken, MintableTokenExt, UpgradeableToke
   function claimTokens(address _token) public onlyOwner {
     require(_token != address(0));
 
-    CrowdsaleTokenExt token = CrowdsaleTokenExt(_token);
+    ERC20 token = ERC20(_token);
     uint balance = token.balanceOf(this);
     token.transfer(owner, balance);
 

--- a/contracts/CrowdsaleTokenExt.sol
+++ b/contracts/CrowdsaleTokenExt.sol
@@ -6,8 +6,6 @@
 
 pragma solidity ^0.4.8;
 
-import "oracles-zeppelin/contracts/token/ERC20.sol";
-
 import './StandardToken.sol';
 import "./UpgradeableToken.sol";
 import "./ReleasableToken.sol";

--- a/contracts/CrowdsaleTokenExt.sol
+++ b/contracts/CrowdsaleTokenExt.sol
@@ -28,6 +28,8 @@ contract CrowdsaleTokenExt is ReleasableToken, MintableTokenExt, UpgradeableToke
   /** Name and symbol were updated. */
   event UpdatedTokenInformation(string newName, string newSymbol);
 
+  event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+
   string public name;
 
   string public symbol;
@@ -110,6 +112,21 @@ contract CrowdsaleTokenExt is ReleasableToken, MintableTokenExt, UpgradeableToke
     symbol = _symbol;
 
     UpdatedTokenInformation(name, symbol);
+  }
+
+  /**
+   * Claim tokens that were accidentally sent to this contract.
+   *
+   * @param _token The address of the token contract that you want to recover.
+   */
+  function claimTokens(address _token) public onlyOwner {
+    require(_token != address(0));
+
+    CrowdsaleTokenExt token = CrowdsaleTokenExt(_token);
+    uint balance = token.balanceOf(this);
+    token.transfer(owner, balance);
+
+    ClaimedTokens(_token, owner, balance);
   }
 
 }


### PR DESCRIPTION
This is a first step for oraclesorg/ico-wizard#284. Some thoughts/questions:

- I didn't implement the "extract ether if address is 0" part because I think that belongs to a different method (or maybe to another contract meant to be extended).
- The `claimTokens` method creates a `CrowdsaleTokenExt` instance, but I think this should work with any `ERC20` token, since it only uses the `balanceOf` and `transfer` methods, right?
- I added a test for the basic flow, but I'll add more tests before merging if you think this is going in the right direction.

@rstormsf would you give me your opinion on this?