### PR TITLE
(Feature) Add Registry contract

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -8,8 +8,11 @@ import "oracles-zeppelin/contracts/ownership/Ownable.sol";
 contract Registry is Ownable {
   mapping (address => address[]) public deployedContracts;
 
+  event Added(address indexed sender);
+
   function add(address deployAddress) public {
     deployedContracts[msg.sender].push(deployAddress);
+    Added(msg.sender);
   }
 
   function count(address deployer) constant returns (uint) {

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -6,15 +6,13 @@ import "oracles-zeppelin/contracts/ownership/Ownable.sol";
  * Registry of contracts deployed from ICO Wizard.
  */
 contract Registry is Ownable {
-  struct DeployedContract {
-    string id;
-    address deployAddress;
-    string extraData;
+  mapping (address => address[]) public deployedContracts;
+
+  function add(address deployAddress) public {
+    deployedContracts[msg.sender].push(deployAddress);
   }
 
-  mapping (address => DeployedContract[]) public deployedContracts;
-
-  function add(string id, address deployAddress, string extraData) public {
-    deployedContracts[msg.sender].push(DeployedContract(id, deployAddress, extraData));
+  function count(address deployer) constant returns (uint) {
+    return deployedContracts[deployer].length;
   }
 }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -8,11 +8,11 @@ import "oracles-zeppelin/contracts/ownership/Ownable.sol";
 contract Registry is Ownable {
   mapping (address => address[]) public deployedContracts;
 
-  event Added(address indexed sender);
+  event Added(address indexed sender, address indexed deployAddress);
 
   function add(address deployAddress) public {
     deployedContracts[msg.sender].push(deployAddress);
-    Added(msg.sender);
+    Added(msg.sender, deployAddress);
   }
 
   function count(address deployer) constant returns (uint) {

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.4.6;
+
+import "oracles-zeppelin/contracts/ownership/Ownable.sol";
+
+/**
+ * Registry of contracts deployed from ICO Wizard.
+ */
+contract Registry is Ownable {
+  struct DeployedContract {
+    string id;
+    address deployAddress;
+    string extraData;
+  }
+
+  mapping (address => DeployedContract[]) public deployedContracts;
+
+  function add(string id, address deployAddress, string extraData) public {
+    deployedContracts[msg.sender].push(DeployedContract(id, deployAddress, extraData));
+  }
+}

--- a/migrations/2_contracts_deploy.js
+++ b/migrations/2_contracts_deploy.js
@@ -4,6 +4,7 @@ const FlatPricingExt = artifacts.require("./FlatPricingExt.sol");
 const MintedTokenCappedCrowdsaleExt = artifacts.require("./MintedTokenCappedCrowdsaleExt.sol");
 const NullFinalizeAgentExt = artifacts.require("./NullFinalizeAgentExt.sol");
 const ReservedTokensFinalizeAgent = artifacts.require("./ReservedTokensFinalizeAgent.sol");
+const Registry = artifacts.require("./Registry.sol");
 
 const constants = require("../test/constants");
 const utils = require("../test/utils");
@@ -64,6 +65,8 @@ module.exports = function(deployer, network, accounts) {
     	await deployer.link(SafeMathLibExt, ReservedTokensFinalizeAgent);
     	await deployer.deploy(ReservedTokensFinalizeAgent, ...reservedTokensFinalizeAgentParams);
 
+        await deployer.deploy(Registry);
+
     	await FlatPricingExt.deployed().then(async (instance) => {
 	    	instance.setLastCrowdsale(MintedTokenCappedCrowdsaleExt.address);
 	    });
@@ -118,4 +121,5 @@ module.exports = function(deployer, network, accounts) {
 	    	await instance.transferOwnership(ReservedTokensFinalizeAgent.address);
 	    });
   	});
+
 };

--- a/test/contracts/Registry.js
+++ b/test/contracts/Registry.js
@@ -1,0 +1,37 @@
+const Registry = artifacts.require("./Registry.sol");
+
+contract('Registry', function(accounts) {
+    it("should start with an empty mapping", function() {
+        return Registry.deployed().then(function(instance) {
+            return instance.deployedContracts.call(accounts[0], 0);
+        }).then(function(res) {
+            assert.fail("Initial value for mapping should be an empty array");
+        }, function () {
+            // Method should fail because array should be empty
+        });
+    });
+
+    it("should add a deployed contract", function() {
+        return Registry.deployed().then(function(instance) {
+            return instance.add("crowdsale", "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab", "{}", { from: accounts[0] })
+                .then(() => {
+                    return instance.deployedContracts.call(accounts[0], 0);
+                })
+                .then(([id, deployedAddress, extraData]) => {
+                    assert.equal(id, "crowdsale")
+                    assert.equal(deployedAddress, "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab")
+                    assert.equal(extraData, "{}")
+                })
+        });
+    })
+    it("should add just one deployed contract", function() {
+        return Registry.deployed().then(function(instance) {
+            return instance.deployedContracts.call(accounts[0], 1)
+                .then(function(res) {
+                    assert.fail("Initial value for mapping should be an empty array");
+                }, function () {
+                    // Method should fail because array should be empty
+                });
+        });
+    })
+});

--- a/test/contracts/Registry.js
+++ b/test/contracts/Registry.js
@@ -11,19 +11,28 @@ contract('Registry', function(accounts) {
         });
     });
 
+    it("should get 0 as number of deployed contracts", function() {
+        return Registry.deployed().then(function(instance) {
+            return instance.count.call(accounts[0]);
+        }).then(function(count) {
+            assert.equal(count, 0);
+        }, function () {
+            // Method should fail because array should be empty
+        });
+    })
+
     it("should add a deployed contract", function() {
         return Registry.deployed().then(function(instance) {
-            return instance.add("crowdsale", "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab", "{}", { from: accounts[0] })
+            return instance.add("0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab", { from: accounts[0] })
                 .then(() => {
                     return instance.deployedContracts.call(accounts[0], 0);
                 })
-                .then(([id, deployedAddress, extraData]) => {
-                    assert.equal(id, "crowdsale")
+                .then((deployedAddress) => {
                     assert.equal(deployedAddress, "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab")
-                    assert.equal(extraData, "{}")
                 })
         });
     })
+
     it("should add just one deployed contract", function() {
         return Registry.deployed().then(function(instance) {
             return instance.deployedContracts.call(accounts[0], 1)
@@ -32,6 +41,16 @@ contract('Registry', function(accounts) {
                 }, function () {
                     // Method should fail because array should be empty
                 });
+        });
+    })
+
+    it("should get 1 as number of deployed contracts", function() {
+        return Registry.deployed().then(function(instance) {
+            return instance.count.call(accounts[0]);
+        }).then(function(count) {
+            assert.equal(count, 1);
+        }, function () {
+            // Method should fail because array should be empty
         });
     })
 });

--- a/test/contracts/Registry.js
+++ b/test/contracts/Registry.js
@@ -54,15 +54,17 @@ contract('Registry', function(accounts) {
         });
     })
 
-    it.only("should emit an Added event when adding an address", function() {
+    it("should emit an Added event when adding an address", function() {
         return Registry.deployed().then(function(instance) {
             const addedWatcher = instance.Added();
+            const crowdsaleAddress = "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab"
 
-            return instance.add("0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab", { from: accounts[0] })
+            return instance.add(crowdsaleAddress, { from: accounts[0] })
                 .then(() => addedWatcher.get())
                 .then((events) => {
                     assert.equal(events.length, 1, "Should have emitted an Added event")
                     assert.equal(events[0].args.sender, accounts[0]);
+                    assert.equal(events[0].args.deployAddress, crowdsaleAddress);
                 })
         });
     })

--- a/test/contracts/Registry.js
+++ b/test/contracts/Registry.js
@@ -53,4 +53,17 @@ contract('Registry', function(accounts) {
             // Method should fail because array should be empty
         });
     })
+
+    it.only("should emit an Added event when adding an address", function() {
+        return Registry.deployed().then(function(instance) {
+            const addedWatcher = instance.Added();
+
+            return instance.add("0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab", { from: accounts[0] })
+                .then(() => addedWatcher.get())
+                .then((events) => {
+                    assert.equal(events.length, 1, "Should have emitted an Added event")
+                    assert.equal(events[0].args.sender, accounts[0]);
+                })
+        });
+    })
 });


### PR DESCRIPTION
This adds a Registry contract that would allow us to know what ICO contracts were created by a given address.

Since, as far as I know, Solidity doesn't support array of strings as function parameters, we'll need to make a transaction for each contract address that we want to associate with the user.