### PR TITLE
(Fix) individual max cap fix for buy from whitelist in batches

### DIFF
--- a/contracts/CrowdsaleExt.sol
+++ b/contracts/CrowdsaleExt.sol
@@ -218,15 +218,13 @@ contract CrowdsaleExt is Haltable {
         // tokenAmount < minCap for investor
         throw;
       }
-      if(tokenAmount > earlyParticipantWhitelist[receiver].maxCap) {
-        // tokenAmount > maxCap for investor
-        throw;
-      }
 
       // Check that we did not bust the investor's cap
       if (isBreakingInvestorCap(receiver, tokenAmount)) {
         throw;
       }
+
+      updateInheritedEarlyParticipantWhitelist(receiver, tokenAmount);
     } else {
       if(tokenAmount < token.minCap() && tokenAmountOf[receiver] == 0) {
         throw;
@@ -255,10 +253,6 @@ contract CrowdsaleExt is Haltable {
 
     // Pocket the money
     if(!multisigWallet.send(weiAmount)) throw;
-
-    if (isWhiteListed) {
-      updateInheritedEarlyParticipantWhitelist(tokenAmount);
-    }
 
     // Tell us invest was success
     Invested(receiver, weiAmount, tokenAmount, customerId);
@@ -348,7 +342,7 @@ contract CrowdsaleExt is Haltable {
     assert(minCap <= maxCap);
     assert(now <= endsAt);
 
-    if (earlyParticipantWhitelist[addr].maxCap == 0) {
+    if (!isAddressWhitelisted(addr)) {
       whitelistedParticipants.push(addr);
       Whitelisted(addr, status, minCap, maxCap);
     } else {
@@ -369,15 +363,15 @@ contract CrowdsaleExt is Haltable {
     }
   }
 
-  function updateInheritedEarlyParticipantWhitelist(uint tokensBought) private {
+  function updateInheritedEarlyParticipantWhitelist(address reciever, uint tokensBought) private {
     if (!isWhiteListed) throw;
-    if (tokensBought < earlyParticipantWhitelist[msg.sender].minCap) throw;
+    if (tokensBought < earlyParticipantWhitelist[reciever].minCap && tokenAmountOf[reciever] == 0) throw;
 
     uint8 tierPosition = getTierPosition(this);
 
-    for (uint8 j = tierPosition; j < joinedCrowdsalesLen; j++) {
+    for (uint8 j = tierPosition + 1; j < joinedCrowdsalesLen; j++) {
       CrowdsaleExt crowdsale = CrowdsaleExt(joinedCrowdsales[j]);
-      crowdsale.updateEarlyParticipantWhitelist(msg.sender, tokensBought);
+      crowdsale.updateEarlyParticipantWhitelist(reciever, tokensBought);
     }
   }
 
@@ -386,11 +380,22 @@ contract CrowdsaleExt is Haltable {
     assert(addr != address(0));
     assert(now <= endsAt);
     assert(isTierJoined(msg.sender));
-    if (tokensBought < earlyParticipantWhitelist[addr].minCap) throw;
+    if (tokensBought < earlyParticipantWhitelist[addr].minCap && tokenAmountOf[addr] == 0) throw;
     //if (addr != msg.sender && contractAddr != msg.sender) throw;
     uint newMaxCap = earlyParticipantWhitelist[addr].maxCap;
     newMaxCap = newMaxCap.minus(tokensBought);
     earlyParticipantWhitelist[addr] = WhiteListData({status:earlyParticipantWhitelist[addr].status, minCap:0, maxCap:newMaxCap});
+  }
+
+  function isAddressWhitelisted(address addr) public constant returns(bool) {
+    for (uint i = 0; i < whitelistedParticipants.length; i++) {
+      if (whitelistedParticipants[i] == addr) {
+        return true;
+        break;
+      }
+    }
+
+    return false;
   }
 
   function whitelistedParticipantsLength() public constant returns (uint) {

--- a/test/constants.js
+++ b/test/constants.js
@@ -29,7 +29,7 @@ const whiteListItem = {
   maxCap: utils.toFixed(10 * 10**token.decimals),
 };
 
-const investments = [0.5, 11, 1, 0.5, 5.5, 4];
+const investments = [0.5, 11, 1, 0.5, 5.5, 4, 3];
 
 const startCrowdsale = parseInt(new Date().getTime()/1000);
 let endCrowdsale = new Date().setDate(new Date().getDate() + 4);

--- a/test/contracts/MintedTokenCappedCrowdsaleExt.js
+++ b/test/contracts/MintedTokenCappedCrowdsaleExt.js
@@ -130,6 +130,20 @@ contract('MintedTokenCappedCrowdsaleExt', function(accounts) {
 		constants.whiteListItem.maxCap.should.be.bignumber.equal(earlyParticipantWhitelistObj[2]);
 	});
 
+	it("checks, that addresses are whitelisted", async () => {
+		let mintedTokenCappedCrowdsaleExt = await MintedTokenCappedCrowdsaleExt.deployed();
+		let isAddress1Whitelisted = await mintedTokenCappedCrowdsaleExt.isAddressWhitelisted.call(accounts[2]);
+		true.should.be.equal(isAddress1Whitelisted);
+		let isAddress2Whitelisted = await mintedTokenCappedCrowdsaleExt.isAddressWhitelisted.call(accounts[4]);
+		true.should.be.equal(isAddress2Whitelisted);
+	});
+
+	it("checks, that address is not whitelisted", async () => {
+		let mintedTokenCappedCrowdsaleExt = await MintedTokenCappedCrowdsaleExt.deployed();
+		let isAddressWhitelisted = await mintedTokenCappedCrowdsaleExt.isAddressWhitelisted.call(accounts[5]);
+		false.should.be.equal(isAddressWhitelisted);
+	});
+
 	it("should not add an address to the whitelist that was already added", async () => {
         let mintedTokenCappedCrowdsaleExt = await MintedTokenCappedCrowdsaleExt.deployed();
         let currentWhitelistLength = await mintedTokenCappedCrowdsaleExt.whitelistedParticipantsLength.call();


### PR DESCRIPTION
Relates to https://github.com/poanetwork/token-wizard/issues/589

**Problem**: Individual max cap for a current tier was redefined when whitelisted user was trying to redeem it in batches. And thus,  he/she could buy less than individual max cap.

**Solution**: Individual max cap should be redefined only for next tiers if a user buys in batches. Tests are updated.

